### PR TITLE
feat(database): source bar tree + plugin DatabaseApi + status path

### DIFF
--- a/apps/onis_viewer/lib/api/core/plugin_manager.dart
+++ b/apps/onis_viewer/lib/api/core/plugin_manager.dart
@@ -25,6 +25,9 @@ class PluginManager {
   final StreamController<String> _logController =
       StreamController<String>.broadcast();
 
+  // Public API registry (pluginId -> api object)
+  final Map<String, Object> _publicApis = {};
+
   // Stream controllers for reactive updates
   final StreamController<OnisViewerPlugin> _pluginLoadedController =
       StreamController<OnisViewerPlugin>.broadcast();
@@ -148,6 +151,12 @@ class PluginManager {
       // Register the plugin
       _loadedPlugins[plugin.id] = plugin;
 
+      // Capture public API if provided
+      final api = plugin.publicApi;
+      if (api != null) {
+        _publicApis[plugin.id] = api;
+      }
+
       // Page types are now registered directly by plugins with PageType.register()
 
       // Notify observers
@@ -185,6 +194,7 @@ class PluginManager {
 
         // Remove the plugin
         _loadedPlugins.remove(pluginId);
+        _publicApis.remove(pluginId);
 
         // Notify observers
         _notifyPluginUnloaded(pluginId);
@@ -213,6 +223,14 @@ class PluginManager {
   /// Get a plugin by ID
   OnisViewerPlugin? getPlugin(String pluginId) {
     return _loadedPlugins[pluginId];
+  }
+
+  /// Get a plugin public API by plugin ID and type
+  T? getPublicApi<T>(String pluginId) {
+    final api = _publicApis[pluginId];
+    if (api == null) return null;
+    if (api is T) return api as T;
+    return null;
   }
 
   /// Get plugin information
@@ -383,6 +401,7 @@ class PluginManager {
 
       // Clear observers
       _observers.clear();
+      _publicApis.clear();
 
       _log('PluginManager disposed');
     } catch (e) {

--- a/apps/onis_viewer/lib/core/plugin_interface.dart
+++ b/apps/onis_viewer/lib/core/plugin_interface.dart
@@ -45,6 +45,10 @@ abstract class OnisViewerPlugin {
   /// Returns true if the plugin is properly configured
   bool get isValid => id.isNotEmpty && name.isNotEmpty && version.isNotEmpty;
 
+  /// Optional: a public API object that can be obtained via the PluginManager
+  /// Consumers can fetch it using getPublicApi<T>(pluginId)
+  Object? get publicApi => null;
+
   @override
   String toString() =>
       'OnisViewerPlugin(id: $id, name: $name, version: $version)';

--- a/apps/onis_viewer/lib/plugins/database/database_plugin.dart
+++ b/apps/onis_viewer/lib/plugins/database/database_plugin.dart
@@ -1,8 +1,38 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 
+import '../../api/core/ov_api_core.dart';
+import '../../core/database_source.dart';
 import '../../core/page_type.dart';
 import '../../core/plugin_interface.dart';
 import 'page/database_page.dart';
+import 'public/database_api.dart';
+
+class _DatabaseApiImpl implements DatabaseApi {
+  final _selectionController = StreamController<DatabaseSource?>.broadcast();
+  DatabaseSource? _selected;
+
+  @override
+  void selectSourceByUid(String uid) {
+    final manager = OVApi().sources;
+    final match = manager.allSources
+        .where((s) => s.uid == uid)
+        .cast<DatabaseSource?>()
+        .firstWhere(
+          (s) => s != null,
+          orElse: () => null,
+        );
+    _selected = match;
+    _selectionController.add(_selected);
+  }
+
+  @override
+  DatabaseSource? get selectedSource => _selected;
+
+  @override
+  Stream<DatabaseSource?> get onSelectionChanged => _selectionController.stream;
+}
 
 /// Database page type constant
 const PageType databasePageType = PageType(
@@ -21,6 +51,8 @@ Widget _createDatabasePage(PageType pageType) {
 
 /// Built-in database plugin
 class DatabasePlugin implements OnisViewerPlugin {
+  _DatabaseApiImpl? _api;
+
   @override
   String get id => 'onis_database_plugin';
 
@@ -46,12 +78,15 @@ class DatabasePlugin implements OnisViewerPlugin {
   Future<void> initialize() async {
     // Register the page type (includes page creator)
     PageType.register(databasePageType);
+    // Create public API implementation
+    _api = _DatabaseApiImpl();
   }
 
   @override
   Future<void> dispose() async {
     // Unregister the page type (includes page creator)
     PageType.unregister(databasePageType.id);
+    _api = null;
   }
 
   @override
@@ -65,4 +100,7 @@ class DatabasePlugin implements OnisViewerPlugin {
         'description': description,
         'author': author,
       };
+
+  @override
+  Object? get publicApi => _api;
 }

--- a/apps/onis_viewer/lib/plugins/database/public/database_api.dart
+++ b/apps/onis_viewer/lib/plugins/database/public/database_api.dart
@@ -1,0 +1,15 @@
+import 'dart:async';
+
+import '../../../core/database_source.dart';
+
+/// Public API exposed by the database plugin
+abstract class DatabaseApi {
+  /// Select a source by UID
+  void selectSourceByUid(String uid);
+
+  /// Currently selected source (if any)
+  DatabaseSource? get selectedSource;
+
+  /// Stream emitting selection changes
+  Stream<DatabaseSource?> get onSelectionChanged;
+}

--- a/apps/onis_viewer/lib/plugins/database/ui/study_list_view.dart
+++ b/apps/onis_viewer/lib/plugins/database/ui/study_list_view.dart
@@ -1,7 +1,12 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 
+import '../../../api/core/ov_api_core.dart';
 import '../../../core/constants.dart';
+import '../../../core/database_source.dart';
 import '../models/study.dart';
+import '../public/database_api.dart';
 import 'resizable_data_table.dart';
 
 /// Study list view using resizable data table
@@ -36,6 +41,25 @@ class _StudyListViewState extends State<StudyListView> {
   int? _sortColumnIndex;
   bool _sortAscending = true;
 
+  DatabaseApi? _dbApi;
+  StreamSubscription<DatabaseSource?>? _selectionSub;
+
+  @override
+  void initState() {
+    super.initState();
+    _dbApi = OVApi().plugins.getPublicApi<DatabaseApi>('onis_database_plugin');
+    _selectionSub = _dbApi?.onSelectionChanged.listen((_) {
+      if (!mounted) return;
+      setState(() {});
+    });
+  }
+
+  @override
+  void dispose() {
+    _selectionSub?.cancel();
+    super.dispose();
+  }
+
   @override
   Widget build(BuildContext context) {
     return Column(
@@ -54,9 +78,9 @@ class _StudyListViewState extends State<StudyListView> {
   /// Build the header section
   Widget _buildHeader() {
     return Container(
-      height: 50,
       padding: const EdgeInsets.symmetric(
         horizontal: OnisViewerConstants.paddingMedium,
+        vertical: OnisViewerConstants.paddingSmall,
       ),
       decoration: BoxDecoration(
         color: OnisViewerConstants.tabBarColor,
@@ -68,6 +92,7 @@ class _StudyListViewState extends State<StudyListView> {
         ),
       ),
       child: Row(
+        crossAxisAlignment: CrossAxisAlignment.center,
         children: [
           const Icon(
             Icons.medical_services,
@@ -78,6 +103,7 @@ class _StudyListViewState extends State<StudyListView> {
           Expanded(
             child: Text(
               'Studies (${widget.studies.length})',
+              overflow: TextOverflow.ellipsis,
               style: const TextStyle(
                 fontWeight: FontWeight.bold,
                 color: OnisViewerConstants.textColor,

--- a/apps/onis_viewer/lib/plugins/sources/site-server/site_server_plugin.dart
+++ b/apps/onis_viewer/lib/plugins/sources/site-server/site_server_plugin.dart
@@ -33,20 +33,27 @@ class SiteServerPlugin implements OnisViewerPlugin {
   Future<void> initialize() async {
     // Future: register source types, services, and any background tasks here
     debugPrint('SiteServerPlugin initialized');
+
     // Register two site server sources
     final api = OVApi();
 
-    SiteSource siteServerSource = SiteSource(
+    final siteServerSource = SiteSource(
         uid: 'site_server_1',
         name: 'Site Server 1',
         metadata: {'type': 'site_server', 'url': 'http://localhost:8080'});
     api.sources.registerSource(siteServerSource);
 
-    siteServerSource = SiteSource(
+    final partition = SiteSource(
+        uid: 'partition_1',
+        name: 'Partition 1',
+        metadata: {'type': 'site_server', 'url': 'http://localhost:8080'});
+    api.sources.registerSource(partition, parentUid: siteServerSource.uid);
+
+    final siteServerSource2 = SiteSource(
         uid: 'site_server_2',
         name: 'Site Server 2',
         metadata: {'type': 'site_server', 'url': 'http://localhost:8080'});
-    api.sources.registerSource(siteServerSource);
+    api.sources.registerSource(siteServerSource2);
 
     debugPrint('Registered 2 site server sources');
   }
@@ -67,4 +74,7 @@ class SiteServerPlugin implements OnisViewerPlugin {
         'description': description,
         'author': author,
       };
+
+  @override
+  Object? get publicApi => null;
 }

--- a/apps/onis_viewer/lib/plugins/viewer/viewer_plugin.dart
+++ b/apps/onis_viewer/lib/plugins/viewer/viewer_plugin.dart
@@ -65,4 +65,7 @@ class ViewerPlugin implements OnisViewerPlugin {
         'description': description,
         'author': author,
       };
+
+  @override
+  Object? get publicApi => null;
 }


### PR DESCRIPTION
This PR introduces:\n\n- A plugin-owned DatabaseApi exposed via publicApi\n- Source bar tree backed by DatabaseSourceManager; selection wired to DatabaseApi\n- StudyListView header stays "Studies (N)"\n- Status bar shows selected source path and updates on selection\n- PluginManager ability to fetch plugin public APIs\n\nBuild/Tests: green\n