### PR TITLE
feat(database): add username display and async disconnect functionality to study list

### DIFF
--- a/apps/onis_viewer/ios/Flutter/Debug.xcconfig
+++ b/apps/onis_viewer/ios/Flutter/Debug.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"

--- a/apps/onis_viewer/ios/Flutter/Release.xcconfig
+++ b/apps/onis_viewer/ios/Flutter/Release.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"

--- a/apps/onis_viewer/ios/Podfile
+++ b/apps/onis_viewer/ios/Podfile
@@ -1,0 +1,44 @@
+# Uncomment this line to define a global platform for your project
+# platform :ios, '12.0'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Generated.xcconfig, then run flutter pub get"
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_ios_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+  use_modular_headers!
+
+  flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
+  target 'RunnerTests' do
+    inherit! :search_paths
+  end
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_ios_build_settings(target)
+  end
+end

--- a/apps/onis_viewer/lib/core/database_source.dart
+++ b/apps/onis_viewer/lib/core/database_source.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 import 'dart:core';
 
-import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
 
 /// Represents a database source with hierarchical structure
 /// Each source can have sub-sources and maintains a weak reference to its parent
@@ -98,87 +98,15 @@ class DatabaseSource extends ChangeNotifier {
     }
   }
 
-  /// Remove a sub-source by its UID
-  /*void removeSubSourceByUid(String uid) {
-    _subSources.removeWhere((source) => source.uid == uid);
-    notifyListeners();
-  }*/
+  /// Optional UI panel for authentication/login when the source is inactive
+  /// Default is null; plugins can override to provide a custom panel.
+  /// When provided and [isActive] is false, the application may render this
+  /// panel instead of the normal content area.
+  Widget? buildLoginPanel(BuildContext context) => null;
 
-  /// Find a sub-source by its UID
-  /*DatabaseSource? findSubSourceByUid(String uid) {
-    return _subSources.where((source) => source.uid == uid).firstOrNull;
-  }*/
-
-  /// Add metadata to this source
-  /*void setMetadata(String key, dynamic value) {
-    _metadata[key] = value;
-    notifyListeners();
-  }
-
-  /// Get metadata value by key
-  dynamic getMetadata(String key) {
-    return _metadata[key];
-  }
-
-  /// Remove metadata by key
-  void removeMetadata(String key) {
-    if (_metadata.remove(key) != null) {
-      notifyListeners();
-    }
-  }*/
-
-  /// Get the root source (traverse up the hierarchy)
-  /*DatabaseSource get root {
-    DatabaseSource current = this;
-    while (current.parent != null) {
-      current = current.parent!;
-    }
-    return current;
-  }
-
-  /// Get the depth of this source in the hierarchy (0 for root)
-  int get depth {
-    int depth = 0;
-    DatabaseSource? current = parent;
-    while (current != null) {
-      depth++;
-      current = current.parent;
-    }
-    return depth;
-  }
-
-  /// Get the full path of this source (from root to this source)
-  List<DatabaseSource> get path {
-    final path = <DatabaseSource>[];
-    DatabaseSource? current = this;
-    while (current != null) {
-      path.insert(0, current);
-      current = current.parent;
-    }
-    return path;
-  }
-
-  /// Get the full path as a string (using names)
-  String get pathString {
-    return path.map((source) => source.name).join(' > ');
-  }
-
-  /// Check if this source is a descendant of the given source
-  bool isDescendantOf(DatabaseSource ancestor) {
-    DatabaseSource? current = parent;
-    while (current != null) {
-      if (current == ancestor) {
-        return true;
-      }
-      current = current.parent;
-    }
-    return false;
-  }
-
-  /// Check if this source is an ancestor of the given source
-  bool isAncestorOf(DatabaseSource descendant) {
-    return descendant.isDescendantOf(this);
-  }*/
+  /// Optional UI panel for connection/properties (e.g., URL, instance name)
+  /// Default is null; plugins can override to provide a custom panel.
+  Widget? buildConnectionPanel(BuildContext context) => null;
 
   /// Get all descendants of this source (recursive)
   List<DatabaseSource> get allDescendants {
@@ -188,6 +116,16 @@ class DatabaseSource extends ChangeNotifier {
       descendants.addAll(subSource.allDescendants);
     }
     return descendants;
+  }
+
+  /// Internal: set or clear the parent weak reference
+  void _setParentInternal(DatabaseSource? parent) {
+    final currentParent = _parentRef?.target;
+    if (identical(currentParent, parent)) {
+      return;
+    }
+    _parentRef = parent != null ? WeakReference(parent) : null;
+    notifyListeners();
   }
 
   /// Get all sources in the subtree (including this source)
@@ -224,16 +162,6 @@ class DatabaseSource extends ChangeNotifier {
   String toString() {
     return 'DatabaseSource(uid: $uid, name: $name, parent: ${parent?.uid}, subSources: ${_subSources.length})';
   }*/
-
-  /// Internal: set or clear the parent weak reference
-  void _setParentInternal(DatabaseSource? parent) {
-    final currentParent = _parentRef?.target;
-    if (identical(currentParent, parent)) {
-      return;
-    }
-    _parentRef = parent != null ? WeakReference(parent) : null;
-    notifyListeners();
-  }
 }
 
 /// Manager class for handling database sources

--- a/apps/onis_viewer/lib/plugins/database/ui/study_list_view.dart
+++ b/apps/onis_viewer/lib/plugins/database/ui/study_list_view.dart
@@ -5,6 +5,8 @@ import 'package:flutter/material.dart';
 import '../../../api/core/ov_api_core.dart';
 import '../../../core/constants.dart';
 import '../../../core/database_source.dart';
+import '../../sources/site-server/site_source.dart';
+import '../../sources/site-server/ui/site_server_login_panel.dart';
 import '../models/study.dart';
 import '../public/database_api.dart';
 import 'resizable_data_table.dart';
@@ -62,14 +64,17 @@ class _StudyListViewState extends State<StudyListView> {
 
   @override
   Widget build(BuildContext context) {
+    final selected = _dbApi?.selectedSource;
+    final shouldShowLogin = selected is SiteSource && !selected.isActive;
+
     return Column(
       children: [
         // Header
         _buildHeader(),
 
-        // Study table
+        // Content
         Expanded(
-          child: _buildStudyTable(),
+          child: shouldShowLogin ? _buildLoginPanel() : _buildStudyTable(),
         ),
       ],
     );
@@ -92,7 +97,6 @@ class _StudyListViewState extends State<StudyListView> {
         ),
       ),
       child: Row(
-        crossAxisAlignment: CrossAxisAlignment.center,
         children: [
           const Icon(
             Icons.medical_services,
@@ -141,6 +145,27 @@ class _StudyListViewState extends State<StudyListView> {
           ),
         ],
       ),
+    );
+  }
+
+  Widget _buildLoginPanel() {
+    return SiteServerLoginPanel(
+      onLogin: () {
+        final selected = _dbApi?.selectedSource;
+        if (selected is SiteSource) {
+          // For now, just mark as active to simulate a successful login
+          setState(() {
+            selected.isActive = true;
+          });
+        }
+      },
+      onShowProperties: () {
+        // TODO: Show properties dialog/page for the site server
+        // Placeholder: Snackbar
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Show Site Server properties')),
+        );
+      },
     );
   }
 

--- a/apps/onis_viewer/lib/plugins/sources/site-server/credentials/credential_store.dart
+++ b/apps/onis_viewer/lib/plugins/sources/site-server/credentials/credential_store.dart
@@ -1,0 +1,97 @@
+import 'dart:convert';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
+class SiteServerCredentials {
+  final String username;
+  final String password;
+  final bool remember;
+  const SiteServerCredentials({
+    required this.username,
+    required this.password,
+    required this.remember,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'username': username,
+        'password': password,
+        'remember': remember,
+      };
+
+  static SiteServerCredentials fromJson(Map<String, dynamic> json) =>
+      SiteServerCredentials(
+        username: json['username'] as String? ?? '',
+        password: json['password'] as String? ?? '',
+        remember: json['remember'] as bool? ?? false,
+      );
+}
+
+class SiteServerCredentialStore {
+  static const _storage = FlutterSecureStorage();
+  static const _prefix = 'site_server_credentials_';
+  static final Map<String, String> _memoryFallback = {};
+
+  static String _key(String sourceUid) => '$_prefix$sourceUid';
+
+  static Future<SiteServerCredentials?> load(String sourceUid) async {
+    final key = _key(sourceUid);
+    try {
+      final raw = await _storage.read(key: key);
+      if (raw == null) return null;
+      final map = jsonDecode(raw) as Map<String, dynamic>;
+      return SiteServerCredentials.fromJson(map);
+    } on PlatformException {
+      final raw = _memoryFallback[key];
+      if (raw == null) return null;
+      try {
+        final map = jsonDecode(raw) as Map<String, dynamic>;
+        return SiteServerCredentials.fromJson(map);
+      } catch (_) {
+        return null;
+      }
+    } catch (_) {
+      return null;
+    }
+  }
+
+  static Future<void> save(
+    String sourceUid, {
+    required String username,
+    required String password,
+    required bool remember,
+  }) async {
+    final key = _key(sourceUid);
+    final data = SiteServerCredentials(
+      username: username,
+      password: password,
+      remember: remember,
+    );
+    final raw = jsonEncode(data.toJson());
+    try {
+      await _storage.write(key: key, value: raw);
+    } on PlatformException {
+      // Fallback to in-memory store to avoid crashes in dev without entitlements
+      _memoryFallback[key] = raw;
+    }
+  }
+
+  static Future<void> clear(String sourceUid) async {
+    final key = _key(sourceUid);
+    try {
+      await _storage.delete(key: key);
+    } on PlatformException {
+      _memoryFallback.remove(key);
+    }
+  }
+
+  static Future<bool> has(String sourceUid) async {
+    final key = _key(sourceUid);
+    try {
+      final v = await _storage.read(key: key);
+      return v != null;
+    } on PlatformException {
+      return _memoryFallback.containsKey(key);
+    }
+  }
+}

--- a/apps/onis_viewer/lib/plugins/sources/site-server/site_source.dart
+++ b/apps/onis_viewer/lib/plugins/sources/site-server/site_source.dart
@@ -1,10 +1,127 @@
 import 'dart:core';
 
+import 'package:flutter/material.dart';
+
 import '../../../core/database_source.dart';
+import 'credentials/credential_store.dart';
+import 'ui/site_server_connection_panel.dart';
+import 'ui/site_server_login_panel.dart';
 
 class SiteSource extends DatabaseSource {
   /// Public constructor for a site source (without parent)
   /// Parent relationships should be managed by DatabaseSourceManager
   SiteSource({required super.uid, required super.name, super.metadata})
       : super();
+
+  // Track last used credentials and pending login per source
+  String? _lastUsername;
+  String? _lastPassword;
+  bool _lastRemember = false;
+  bool _isLoggingIn = false;
+  bool _isDisconnecting = false;
+
+  /// Get the current logged-in username (if any)
+  String? get currentUsername => _lastUsername;
+
+  /// Get whether the source is currently disconnecting
+  bool get isDisconnecting => _isDisconnecting;
+
+  /// Disconnect from the source
+  Future<void> disconnect() async {
+    _isDisconnecting = true;
+    notifyListeners();
+
+    // Simulate slow server response for disconnect
+    await Future.delayed(const Duration(seconds: 10));
+
+    // Mark source as disconnected
+    isActive = false;
+    _lastUsername = null;
+    _lastPassword = null;
+    _lastRemember = false;
+    _isLoggingIn = false;
+    _isDisconnecting = false;
+    notifyListeners();
+  }
+
+  /// Mock login: optionally store credentials, wait 10 seconds, then mark active
+  Future<void> login({
+    required String username,
+    required String password,
+    required bool remember,
+  }) async {
+    _lastUsername = username;
+    _lastPassword = password;
+    _lastRemember = remember;
+    _isLoggingIn = true;
+    notifyListeners();
+
+    if (remember) {
+      await SiteServerCredentialStore.save(
+        uid,
+        username: username,
+        password: password,
+        remember: true,
+      );
+    } else {
+      await SiteServerCredentialStore.clear(uid);
+    }
+
+    // Simulate slow server response
+    await Future.delayed(const Duration(seconds: 10));
+
+    // Mark source as connected
+    isActive = true; // Triggers listeners via setter
+
+    // Reset logging-in flag
+    _isLoggingIn = false;
+    notifyListeners();
+  }
+
+  @override
+  Widget? buildLoginPanel(BuildContext context) {
+    return KeyedSubtree(
+      key: ValueKey<String>('login-$uid'),
+      child: FutureBuilder<SiteServerCredentials?>(
+        future: SiteServerCredentialStore.load(uid),
+        builder: (context, snapshot) {
+          final saved = snapshot.data;
+          final initialUsername = _isLoggingIn
+              ? (_lastUsername ?? saved?.username)
+              : (saved?.username);
+          final initialPassword = _isLoggingIn
+              ? (_lastPassword ?? saved?.password)
+              : (saved?.password);
+          final initialRemember =
+              _isLoggingIn ? _lastRemember : (saved?.remember ?? false);
+          return SiteServerLoginPanel(
+            initialUsername: initialUsername,
+            initialPassword: initialPassword,
+            initialRemember: initialRemember,
+            initialSubmitting: _isLoggingIn,
+            instanceName: name,
+            onSubmitAsync: (username, password, remember) async {
+              await login(
+                username: username,
+                password: password,
+                remember: remember,
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+
+  @override
+  Widget? buildConnectionPanel(BuildContext context) {
+    // Metadata keys are optional; adjust as needed
+    final url = metadata['url'] as String?;
+    final instanceName = name;
+    return SiteServerConnectionPanel(
+      initialUrl: url,
+      initialInstanceName: instanceName,
+      onSave: () {},
+    );
+  }
 }

--- a/apps/onis_viewer/lib/plugins/sources/site-server/ui/site_server_connection_panel.dart
+++ b/apps/onis_viewer/lib/plugins/sources/site-server/ui/site_server_connection_panel.dart
@@ -1,0 +1,203 @@
+import 'package:flutter/material.dart';
+
+import '../../../../core/constants.dart';
+
+class SiteServerConnectionPanel extends StatefulWidget {
+  final String? initialUrl;
+  final String? initialInstanceName;
+  final ValueChanged<String>? onUrlChanged;
+  final ValueChanged<String>? onInstanceNameChanged;
+  final VoidCallback? onSave;
+  final VoidCallback? onCancel;
+
+  const SiteServerConnectionPanel({
+    super.key,
+    this.initialUrl,
+    this.initialInstanceName,
+    this.onUrlChanged,
+    this.onInstanceNameChanged,
+    this.onSave,
+    this.onCancel,
+  });
+
+  @override
+  State<SiteServerConnectionPanel> createState() =>
+      _SiteServerConnectionPanelState();
+}
+
+class _SiteServerConnectionPanelState extends State<SiteServerConnectionPanel> {
+  late final TextEditingController _urlController;
+  late final TextEditingController _nameController;
+
+  @override
+  void initState() {
+    super.initState();
+    _urlController = TextEditingController(text: widget.initialUrl ?? '');
+    _nameController =
+        TextEditingController(text: widget.initialInstanceName ?? '');
+  }
+
+  @override
+  void dispose() {
+    _urlController.dispose();
+    _nameController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: LayoutBuilder(builder: (context, constraints) {
+        final maxWidth =
+            constraints.maxWidth < 560 ? constraints.maxWidth - 48 : 520.0;
+        return ConstrainedBox(
+          constraints: BoxConstraints(maxWidth: maxWidth),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              // Header with icon + title (no cancel here)
+              Row(
+                children: [
+                  Container(
+                    height: 28,
+                    width: 28,
+                    decoration: BoxDecoration(
+                      color: OnisViewerConstants.primaryColor
+                          .withValues(alpha: 0.18),
+                      borderRadius: BorderRadius.circular(6),
+                    ),
+                    child: const Icon(
+                      Icons.settings_outlined,
+                      color: OnisViewerConstants.primaryColor,
+                      size: 20,
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  const Text(
+                    'Connection settings',
+                    style: TextStyle(
+                      color: OnisViewerConstants.textColor,
+                      fontSize: 18,
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 16),
+              _buildTextField(
+                label: 'Connection URL',
+                controller: _urlController,
+                hintText: 'https://your-site-server.example',
+                icon: Icons.link_outlined,
+                onChanged: widget.onUrlChanged,
+              ),
+              const SizedBox(height: 18),
+              _buildTextField(
+                label: 'Instance name',
+                controller: _nameController,
+                hintText: 'My Site Server',
+                icon: Icons.badge_outlined,
+                onChanged: widget.onInstanceNameChanged,
+              ),
+              const SizedBox(height: 18),
+              // Bottom actions: Cancel (left) and Save (right)
+              Row(
+                children: [
+                  TextButton(
+                    onPressed: widget.onCancel ?? () {},
+                    style: TextButton.styleFrom(
+                      foregroundColor: OnisViewerConstants.textSecondaryColor,
+                      padding: const EdgeInsets.symmetric(
+                          horizontal: 12, vertical: 10),
+                      shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(8)),
+                    ),
+                    child: const Text('Cancel',
+                        style: TextStyle(
+                            fontSize: 14, fontWeight: FontWeight.w600)),
+                  ),
+                  const Spacer(),
+                  SizedBox(
+                    height: 44,
+                    child: ElevatedButton(
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: OnisViewerConstants.primaryColor,
+                        foregroundColor: Colors.white,
+                        shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(10)),
+                        padding: const EdgeInsets.symmetric(horizontal: 18),
+                        elevation: 0,
+                      ),
+                      onPressed: widget.onSave ?? () {},
+                      child: const Text('Save',
+                          style: TextStyle(fontWeight: FontWeight.w700)),
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        );
+      }),
+    );
+  }
+
+  Widget _buildTextField({
+    required String label,
+    required TextEditingController controller,
+    required String hintText,
+    required IconData icon,
+    ValueChanged<String>? onChanged,
+  }) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          label,
+          style: const TextStyle(
+            color: OnisViewerConstants.textSecondaryColor,
+            fontSize: 13,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        const SizedBox(height: 8),
+        Container(
+          height: 44,
+          decoration: BoxDecoration(
+            color: const Color(0xFF2C2A2B),
+            borderRadius: BorderRadius.circular(10),
+            border: Border.all(color: Colors.grey.shade800),
+          ),
+          child: Row(
+            children: [
+              const SizedBox(width: 12),
+              Icon(icon,
+                  size: 18, color: OnisViewerConstants.textSecondaryColor),
+              const SizedBox(width: 8),
+              Expanded(
+                child: TextField(
+                  controller: controller,
+                  onChanged: onChanged,
+                  textAlignVertical: TextAlignVertical.center,
+                  decoration: InputDecoration(
+                    isDense: true,
+                    border: InputBorder.none,
+                    hintText: hintText,
+                    hintStyle: const TextStyle(
+                        color: OnisViewerConstants.textSecondaryColor),
+                  ),
+                  style: const TextStyle(
+                    color: OnisViewerConstants.textColor,
+                    fontSize: 15,
+                  ),
+                ),
+              ),
+              const SizedBox(width: 6),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/apps/onis_viewer/lib/plugins/sources/site-server/ui/site_server_login_panel.dart
+++ b/apps/onis_viewer/lib/plugins/sources/site-server/ui/site_server_login_panel.dart
@@ -1,30 +1,89 @@
 import 'package:flutter/material.dart';
 
 import '../../../../core/constants.dart';
+import 'site_server_connection_panel.dart';
 
 class SiteServerLoginPanel extends StatefulWidget {
   final VoidCallback? onLogin;
-  final VoidCallback? onShowProperties;
+  final VoidCallback? onShowProperties; // deprecated in favor of inline panel
   final String? instanceName;
+  final String? initialUrl;
+  final String? initialUsername;
+  final String? initialPassword;
+  final bool initialRemember;
+  final Future<void> Function(String username, String password, bool remember)?
+      onSubmitAsync;
+  final bool initialSubmitting;
 
   const SiteServerLoginPanel({
     super.key,
     this.onLogin,
     this.onShowProperties,
     this.instanceName,
+    this.initialUrl,
+    this.initialUsername,
+    this.initialPassword,
+    this.initialRemember = false,
+    this.onSubmitAsync,
+    this.initialSubmitting = false,
   });
 
   @override
   State<SiteServerLoginPanel> createState() => _SiteServerLoginPanelState();
 }
 
-class _SiteServerLoginPanelState extends State<SiteServerLoginPanel> {
+class _SiteServerLoginPanelState extends State<SiteServerLoginPanel>
+    with TickerProviderStateMixin {
   final TextEditingController _userController = TextEditingController();
   final TextEditingController _passwordController = TextEditingController();
   bool _isPasswordHidden = true;
+  bool _showSettings = false;
+  bool _remember = false;
+  bool _canSubmit = false;
+  bool _isSubmitting = false;
+
+  void _recomputeCanSubmit() {
+    final can = _userController.text.trim().isNotEmpty &&
+        _passwordController.text.isNotEmpty;
+    if (can != _canSubmit && mounted) {
+      setState(() => _canSubmit = can);
+    } else {
+      _canSubmit = can;
+    }
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _userController.text = widget.initialUsername ?? '';
+    _passwordController.text = widget.initialPassword ?? '';
+    _remember = widget.initialRemember;
+    _isSubmitting = widget.initialSubmitting;
+    _recomputeCanSubmit();
+    _userController.addListener(_recomputeCanSubmit);
+    _passwordController.addListener(_recomputeCanSubmit);
+  }
+
+  @override
+  void didUpdateWidget(covariant SiteServerLoginPanel oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.initialUsername != oldWidget.initialUsername ||
+        widget.initialPassword != oldWidget.initialPassword ||
+        widget.initialRemember != oldWidget.initialRemember) {
+      _userController.text = widget.initialUsername ?? '';
+      _passwordController.text = widget.initialPassword ?? '';
+      _remember = widget.initialRemember;
+      _recomputeCanSubmit();
+    }
+    if (widget.initialSubmitting != oldWidget.initialSubmitting) {
+      _isSubmitting = widget.initialSubmitting;
+    }
+  }
 
   @override
   void dispose() {
+    _userController.removeListener(_recomputeCanSubmit);
+    _passwordController.removeListener(_recomputeCanSubmit);
     _userController.dispose();
     _passwordController.dispose();
     super.dispose();
@@ -36,72 +95,39 @@ class _SiteServerLoginPanelState extends State<SiteServerLoginPanel> {
       child: LayoutBuilder(
         builder: (context, constraints) {
           final maxWidth =
-              constraints.maxWidth < 640 ? constraints.maxWidth - 48 : 560.0;
+              constraints.maxWidth < 440 ? constraints.maxWidth - 48 : 360.0;
           return ConstrainedBox(
             constraints: BoxConstraints(maxWidth: maxWidth),
-            child: Container(
-              padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 20),
-              decoration: BoxDecoration(
-                color: OnisViewerConstants.surfaceColor,
-                borderRadius: BorderRadius.circular(12),
-                border: Border.all(color: Colors.grey.shade800, width: 1),
-                boxShadow: [
-                  BoxShadow(
-                    color: Colors.black.withValues(alpha: 0.22),
-                    blurRadius: 20,
-                    offset: const Offset(0, 10),
-                  ),
-                ],
-              ),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 0, vertical: 4),
               child: Column(
                 mainAxisSize: MainAxisSize.min,
                 crossAxisAlignment: CrossAxisAlignment.stretch,
                 children: [
-                  _buildHeader(),
+                  AnimatedCrossFade(
+                    duration: const Duration(milliseconds: 250),
+                    reverseDuration: const Duration(milliseconds: 250),
+                    firstCurve: Curves.easeOutCubic,
+                    secondCurve: Curves.easeOutCubic,
+                    sizeCurve: Curves.decelerate,
+                    firstChild: _buildHeaderLoginOnly(),
+                    secondChild: _buildHeaderSettingsOnly(),
+                    crossFadeState: _showSettings
+                        ? CrossFadeState.showSecond
+                        : CrossFadeState.showFirst,
+                  ),
                   const SizedBox(height: 16),
-                  _buildTextField(
-                    label: 'User name',
-                    controller: _userController,
-                    icon: Icons.person_outline,
-                  ),
-                  const SizedBox(height: 14),
-                  _buildTextField(
-                    label: 'Password',
-                    controller: _passwordController,
-                    icon: Icons.lock_outline,
-                    obscure: _isPasswordHidden,
-                    trailing: IconButton(
-                      tooltip:
-                          _isPasswordHidden ? 'Show password' : 'Hide password',
-                      visualDensity: VisualDensity.compact,
-                      padding: EdgeInsets.zero,
-                      constraints:
-                          const BoxConstraints(minWidth: 36, minHeight: 36),
-                      icon: Icon(
-                        _isPasswordHidden
-                            ? Icons.visibility_outlined
-                            : Icons.visibility_off_outlined,
-                        size: 18,
-                        color: OnisViewerConstants.textSecondaryColor,
-                      ),
-                      onPressed: () => setState(
-                          () => _isPasswordHidden = !_isPasswordHidden),
-                    ),
-                  ),
-                  const SizedBox(height: 18),
-                  Row(
-                    children: [
-                      _buildTonalButton(
-                        icon: Icons.settings_outlined,
-                        label: 'Connection settings',
-                        onPressed: widget.onShowProperties,
-                      ),
-                      const Spacer(),
-                      _buildPrimaryButton(
-                        label: 'Sign in',
-                        onPressed: widget.onLogin,
-                      ),
-                    ],
+                  AnimatedSwitcher(
+                    duration: const Duration(milliseconds: 250),
+                    switchInCurve: Curves.easeOutCubic,
+                    switchOutCurve: Curves.easeInCubic,
+                    transitionBuilder: (child, animation) {
+                      return FadeTransition(opacity: animation, child: child);
+                    },
+                    child: _showSettings
+                        ? _buildConnectionSettings()
+                            .withKey(const ValueKey('settings'))
+                        : _buildLoginForm().withKey(const ValueKey('login')),
                   ),
                 ],
               ),
@@ -112,7 +138,37 @@ class _SiteServerLoginPanelState extends State<SiteServerLoginPanel> {
     );
   }
 
-  Widget _buildHeader() {
+  // Headers (separated for smooth cross-fade)
+  Widget _buildHeaderSettingsOnly() {
+    return Row(
+      children: [
+        Container(
+          height: 36,
+          width: 36,
+          decoration: BoxDecoration(
+            color: OnisViewerConstants.primaryColor.withValues(alpha: 0.18),
+            borderRadius: BorderRadius.circular(8),
+          ),
+          child: const Icon(
+            Icons.settings_outlined,
+            color: OnisViewerConstants.primaryColor,
+            size: 20,
+          ),
+        ),
+        const SizedBox(width: 12),
+        const Text(
+          'Connection settings',
+          style: TextStyle(
+            color: OnisViewerConstants.textColor,
+            fontSize: 16,
+            fontWeight: FontWeight.w700,
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildHeaderLoginOnly() {
     final subtitle =
         widget.instanceName != null && widget.instanceName!.isNotEmpty
             ? 'Sign in to ${widget.instanceName}'
@@ -136,7 +192,7 @@ class _SiteServerLoginPanelState extends State<SiteServerLoginPanel> {
             mainAxisSize: MainAxisSize.min,
             children: [
               const Text(
-                'Sign in',
+                'Login',
                 style: TextStyle(
                   color: OnisViewerConstants.textColor,
                   fontSize: 18,
@@ -155,6 +211,85 @@ class _SiteServerLoginPanelState extends State<SiteServerLoginPanel> {
           ),
         ),
       ],
+    );
+  }
+
+  // Login form content
+  Widget _buildLoginForm() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        _buildTextField(
+          label: 'User name',
+          controller: _userController,
+          icon: Icons.person_outline,
+        ),
+        const SizedBox(height: 14),
+        _buildTextField(
+          label: 'Password',
+          controller: _passwordController,
+          icon: Icons.lock_outline,
+          obscure: _isPasswordHidden,
+          trailing: IconButton(
+            tooltip: _isPasswordHidden ? 'Show password' : 'Hide password',
+            visualDensity: VisualDensity.compact,
+            padding: EdgeInsets.zero,
+            constraints: const BoxConstraints(minWidth: 36, minHeight: 36),
+            icon: Icon(
+              _isPasswordHidden
+                  ? Icons.visibility_outlined
+                  : Icons.visibility_off_outlined,
+              size: 18,
+              color: OnisViewerConstants.textSecondaryColor,
+            ),
+            onPressed: () =>
+                setState(() => _isPasswordHidden = !_isPasswordHidden),
+          ),
+        ),
+        const SizedBox(height: 24),
+        Row(
+          children: [
+            _buildTonalButton(
+              icon: Icons.settings_outlined,
+              label: 'Connection settings',
+              onPressed: _isSubmitting
+                  ? null
+                  : () => setState(() => _showSettings = true),
+            ),
+            const Spacer(),
+            _buildPrimaryButton(
+              label: _isSubmitting ? 'Signing in...' : 'Sign in',
+              isLoading: _isSubmitting,
+              onPressed: (!_canSubmit || _isSubmitting)
+                  ? null
+                  : (widget.onSubmitAsync != null
+                      ? () async {
+                          setState(() => _isSubmitting = true);
+                          try {
+                            await widget.onSubmitAsync!.call(
+                              _userController.text,
+                              _passwordController.text,
+                              _remember,
+                            );
+                          } finally {
+                            if (mounted) setState(() => _isSubmitting = false);
+                          }
+                        }
+                      : (widget.onLogin ?? () {})),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  // Connection settings content
+  Widget _buildConnectionSettings() {
+    return SiteServerConnectionPanel(
+      initialUrl: widget.initialUrl,
+      initialInstanceName: widget.instanceName,
+      onSave: () => setState(() => _showSettings = false),
+      onCancel: () => setState(() => _showSettings = false),
     );
   }
 
@@ -194,6 +329,7 @@ class _SiteServerLoginPanelState extends State<SiteServerLoginPanel> {
                 child: TextField(
                   controller: controller,
                   obscureText: obscure,
+                  enabled: !_isSubmitting,
                   textAlignVertical: TextAlignVertical.center,
                   decoration: const InputDecoration(
                     isDense: true,
@@ -211,11 +347,37 @@ class _SiteServerLoginPanelState extends State<SiteServerLoginPanel> {
             ],
           ),
         ),
+        if (label == 'Password') ...[
+          const SizedBox(height: 20),
+          Row(
+            children: [
+              SizedBox(
+                width: 18,
+                height: 18,
+                child: Checkbox(
+                  value: _remember,
+                  onChanged: (v) => setState(() => _remember = v ?? false),
+                  materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                  visualDensity: VisualDensity.compact,
+                ),
+              ),
+              const SizedBox(width: 8),
+              const Text('Remember me',
+                  style: TextStyle(
+                    color: OnisViewerConstants.textSecondaryColor,
+                    fontSize: 13,
+                  )),
+            ],
+          ),
+        ],
       ],
     );
   }
 
-  Widget _buildPrimaryButton({required String label, VoidCallback? onPressed}) {
+  Widget _buildPrimaryButton(
+      {required String label,
+      VoidCallback? onPressed,
+      bool isLoading = false}) {
     return SizedBox(
       height: 44,
       child: ElevatedButton(
@@ -228,10 +390,30 @@ class _SiteServerLoginPanelState extends State<SiteServerLoginPanel> {
           elevation: 0,
         ),
         onPressed: onPressed,
-        child: Text(
-          label,
-          style: const TextStyle(
-              fontSize: 16, fontWeight: FontWeight.w700, letterSpacing: 0.3),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            if (isLoading) ...[
+              SizedBox(
+                width: 16,
+                height: 16,
+                child: CircularProgressIndicator(
+                  strokeWidth: 2,
+                  valueColor: const AlwaysStoppedAnimation<Color>(Colors.white),
+                ),
+              ),
+              const SizedBox(width: 10),
+            ],
+            Text(
+              label,
+              style: const TextStyle(
+                fontSize: 16,
+                fontWeight: FontWeight.w700,
+                letterSpacing: 0.3,
+              ),
+            ),
+          ],
         ),
       ),
     );
@@ -262,4 +444,8 @@ class _SiteServerLoginPanelState extends State<SiteServerLoginPanel> {
       ),
     );
   }
+}
+
+extension _WithKey on Widget {
+  Widget withKey(Key key) => KeyedSubtree(key: key, child: this);
 }

--- a/apps/onis_viewer/lib/plugins/sources/site-server/ui/site_server_login_panel.dart
+++ b/apps/onis_viewer/lib/plugins/sources/site-server/ui/site_server_login_panel.dart
@@ -1,0 +1,265 @@
+import 'package:flutter/material.dart';
+
+import '../../../../core/constants.dart';
+
+class SiteServerLoginPanel extends StatefulWidget {
+  final VoidCallback? onLogin;
+  final VoidCallback? onShowProperties;
+  final String? instanceName;
+
+  const SiteServerLoginPanel({
+    super.key,
+    this.onLogin,
+    this.onShowProperties,
+    this.instanceName,
+  });
+
+  @override
+  State<SiteServerLoginPanel> createState() => _SiteServerLoginPanelState();
+}
+
+class _SiteServerLoginPanelState extends State<SiteServerLoginPanel> {
+  final TextEditingController _userController = TextEditingController();
+  final TextEditingController _passwordController = TextEditingController();
+  bool _isPasswordHidden = true;
+
+  @override
+  void dispose() {
+    _userController.dispose();
+    _passwordController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          final maxWidth =
+              constraints.maxWidth < 640 ? constraints.maxWidth - 48 : 560.0;
+          return ConstrainedBox(
+            constraints: BoxConstraints(maxWidth: maxWidth),
+            child: Container(
+              padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 20),
+              decoration: BoxDecoration(
+                color: OnisViewerConstants.surfaceColor,
+                borderRadius: BorderRadius.circular(12),
+                border: Border.all(color: Colors.grey.shade800, width: 1),
+                boxShadow: [
+                  BoxShadow(
+                    color: Colors.black.withValues(alpha: 0.22),
+                    blurRadius: 20,
+                    offset: const Offset(0, 10),
+                  ),
+                ],
+              ),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  _buildHeader(),
+                  const SizedBox(height: 16),
+                  _buildTextField(
+                    label: 'User name',
+                    controller: _userController,
+                    icon: Icons.person_outline,
+                  ),
+                  const SizedBox(height: 14),
+                  _buildTextField(
+                    label: 'Password',
+                    controller: _passwordController,
+                    icon: Icons.lock_outline,
+                    obscure: _isPasswordHidden,
+                    trailing: IconButton(
+                      tooltip:
+                          _isPasswordHidden ? 'Show password' : 'Hide password',
+                      visualDensity: VisualDensity.compact,
+                      padding: EdgeInsets.zero,
+                      constraints:
+                          const BoxConstraints(minWidth: 36, minHeight: 36),
+                      icon: Icon(
+                        _isPasswordHidden
+                            ? Icons.visibility_outlined
+                            : Icons.visibility_off_outlined,
+                        size: 18,
+                        color: OnisViewerConstants.textSecondaryColor,
+                      ),
+                      onPressed: () => setState(
+                          () => _isPasswordHidden = !_isPasswordHidden),
+                    ),
+                  ),
+                  const SizedBox(height: 18),
+                  Row(
+                    children: [
+                      _buildTonalButton(
+                        icon: Icons.settings_outlined,
+                        label: 'Connection settings',
+                        onPressed: widget.onShowProperties,
+                      ),
+                      const Spacer(),
+                      _buildPrimaryButton(
+                        label: 'Sign in',
+                        onPressed: widget.onLogin,
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildHeader() {
+    final subtitle =
+        widget.instanceName != null && widget.instanceName!.isNotEmpty
+            ? 'Sign in to ${widget.instanceName}'
+            : 'Authentication required to access this source';
+    return Row(
+      children: [
+        Container(
+          height: 36,
+          width: 36,
+          decoration: BoxDecoration(
+            color: OnisViewerConstants.primaryColor.withValues(alpha: 0.18),
+            borderRadius: BorderRadius.circular(8),
+          ),
+          child: const Icon(Icons.lock_outline,
+              color: OnisViewerConstants.primaryColor, size: 20),
+        ),
+        const SizedBox(width: 12),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const Text(
+                'Sign in',
+                style: TextStyle(
+                  color: OnisViewerConstants.textColor,
+                  fontSize: 18,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+              const SizedBox(height: 2),
+              Text(
+                subtitle,
+                style: const TextStyle(
+                  color: OnisViewerConstants.textSecondaryColor,
+                  fontSize: 13,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildTextField({
+    required String label,
+    required TextEditingController controller,
+    required IconData icon,
+    bool obscure = false,
+    Widget? trailing,
+  }) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          label,
+          style: const TextStyle(
+            color: OnisViewerConstants.textSecondaryColor,
+            fontSize: 13,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        const SizedBox(height: 8),
+        Container(
+          height: 44,
+          decoration: BoxDecoration(
+            color: const Color(0xFF2C2A2B),
+            borderRadius: BorderRadius.circular(10),
+            border: Border.all(color: Colors.grey.shade800),
+          ),
+          child: Row(
+            children: [
+              const SizedBox(width: 12),
+              Icon(icon,
+                  size: 18, color: OnisViewerConstants.textSecondaryColor),
+              const SizedBox(width: 8),
+              Expanded(
+                child: TextField(
+                  controller: controller,
+                  obscureText: obscure,
+                  textAlignVertical: TextAlignVertical.center,
+                  decoration: const InputDecoration(
+                    isDense: true,
+                    border: InputBorder.none,
+                    hintText: '',
+                  ),
+                  style: const TextStyle(
+                    color: OnisViewerConstants.textColor,
+                    fontSize: 15,
+                  ),
+                ),
+              ),
+              if (trailing != null) trailing,
+              const SizedBox(width: 6),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildPrimaryButton({required String label, VoidCallback? onPressed}) {
+    return SizedBox(
+      height: 44,
+      child: ElevatedButton(
+        style: ElevatedButton.styleFrom(
+          backgroundColor: OnisViewerConstants.primaryColor,
+          foregroundColor: Colors.white,
+          padding: const EdgeInsets.symmetric(horizontal: 22),
+          shape:
+              RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
+          elevation: 0,
+        ),
+        onPressed: onPressed,
+        child: Text(
+          label,
+          style: const TextStyle(
+              fontSize: 16, fontWeight: FontWeight.w700, letterSpacing: 0.3),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildTonalButton(
+      {required IconData icon,
+      required String label,
+      VoidCallback? onPressed}) {
+    return SizedBox(
+      height: 44,
+      child: OutlinedButton.icon(
+        style: OutlinedButton.styleFrom(
+          backgroundColor: Colors.grey.shade900,
+          foregroundColor: OnisViewerConstants.textColor,
+          side: BorderSide(color: Colors.grey.shade800),
+          shape:
+              RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
+          padding: const EdgeInsets.symmetric(horizontal: 14),
+        ),
+        onPressed: onPressed,
+        icon:
+            Icon(icon, size: 18, color: OnisViewerConstants.textSecondaryColor),
+        label: Text(
+          label,
+          style: const TextStyle(fontSize: 14, fontWeight: FontWeight.w600),
+        ),
+      ),
+    );
+  }
+}

--- a/apps/onis_viewer/linux/flutter/generated_plugin_registrant.cc
+++ b/apps/onis_viewer/linux/flutter/generated_plugin_registrant.cc
@@ -6,6 +6,10 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <flutter_secure_storage_linux/flutter_secure_storage_linux_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
+  g_autoptr(FlPluginRegistrar) flutter_secure_storage_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "FlutterSecureStorageLinuxPlugin");
+  flutter_secure_storage_linux_plugin_register_with_registrar(flutter_secure_storage_linux_registrar);
 }

--- a/apps/onis_viewer/linux/flutter/generated_plugins.cmake
+++ b/apps/onis_viewer/linux/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  flutter_secure_storage_linux
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/apps/onis_viewer/macos/Flutter/Flutter-Debug.xcconfig
+++ b/apps/onis_viewer/macos/Flutter/Flutter-Debug.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "ephemeral/Flutter-Generated.xcconfig"

--- a/apps/onis_viewer/macos/Flutter/Flutter-Release.xcconfig
+++ b/apps/onis_viewer/macos/Flutter/Flutter-Release.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "ephemeral/Flutter-Generated.xcconfig"

--- a/apps/onis_viewer/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/apps/onis_viewer/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,6 +5,10 @@
 import FlutterMacOS
 import Foundation
 
+import flutter_secure_storage_macos
+import path_provider_foundation
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  FlutterSecureStoragePlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStoragePlugin"))
+  PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
 }

--- a/apps/onis_viewer/macos/Podfile
+++ b/apps/onis_viewer/macos/Podfile
@@ -1,0 +1,43 @@
+platform :osx, '10.14'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'ephemeral', 'Flutter-Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure \"flutter pub get\" is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Flutter-Generated.xcconfig, then run \"flutter pub get\""
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_macos_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+  use_modular_headers!
+
+  flutter_install_all_macos_pods File.dirname(File.realpath(__FILE__))
+  target 'RunnerTests' do
+    inherit! :search_paths
+  end
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_macos_build_settings(target)
+  end
+end

--- a/apps/onis_viewer/macos/Podfile.lock
+++ b/apps/onis_viewer/macos/Podfile.lock
@@ -1,0 +1,29 @@
+PODS:
+  - flutter_secure_storage_macos (6.1.3):
+    - FlutterMacOS
+  - FlutterMacOS (1.0.0)
+  - path_provider_foundation (0.0.1):
+    - Flutter
+    - FlutterMacOS
+
+DEPENDENCIES:
+  - flutter_secure_storage_macos (from `Flutter/ephemeral/.symlinks/plugins/flutter_secure_storage_macos/macos`)
+  - FlutterMacOS (from `Flutter/ephemeral`)
+  - path_provider_foundation (from `Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/darwin`)
+
+EXTERNAL SOURCES:
+  flutter_secure_storage_macos:
+    :path: Flutter/ephemeral/.symlinks/plugins/flutter_secure_storage_macos/macos
+  FlutterMacOS:
+    :path: Flutter/ephemeral
+  path_provider_foundation:
+    :path: Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/darwin
+
+SPEC CHECKSUMS:
+  flutter_secure_storage_macos: c2754d3483d20bb207bb9e5a14f1b8e771abcdb9
+  FlutterMacOS: 8f6f14fa908a6fb3fba0cd85dbd81ec4b251fb24
+  path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
+
+PODFILE CHECKSUM: 236401fc2c932af29a9fcf0e97baeeb2d750d367
+
+COCOAPODS: 1.12.0

--- a/apps/onis_viewer/macos/Runner.xcodeproj/project.pbxproj
+++ b/apps/onis_viewer/macos/Runner.xcodeproj/project.pbxproj
@@ -21,12 +21,14 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		018959081DD7A146F6DAC97A /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8707ADDE72BD4B5DBD364734 /* Pods_RunnerTests.framework */; };
 		331C80D8294CF71000263BE5 /* RunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C80D7294CF71000263BE5 /* RunnerTests.swift */; };
 		335BBD1B22A9A15E00E9071D /* GeneratedPluginRegistrant.swift in Sources */ = {isa = PBXBuildFile; fileRef = 335BBD1A22A9A15E00E9071D /* GeneratedPluginRegistrant.swift */; };
 		33CC10F12044A3C60003C045 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33CC10F02044A3C60003C045 /* AppDelegate.swift */; };
 		33CC10F32044A3C60003C045 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F22044A3C60003C045 /* Assets.xcassets */; };
 		33CC10F62044A3C60003C045 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F42044A3C60003C045 /* MainMenu.xib */; };
 		33CC11132044BFA00003C045 /* MainFlutterWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33CC11122044BFA00003C045 /* MainFlutterWindow.swift */; };
+		D1BB3608E86D19244110874E /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2446A64604057A5E541F024C /* Pods_Runner.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -60,11 +62,14 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		0FE8233AD849D8BF5A54707A /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
+		1C81B2EFC70E239FA9EF3546 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
+		2446A64604057A5E541F024C /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		331C80D5294CF71000263BE5 /* RunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		331C80D7294CF71000263BE5 /* RunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerTests.swift; sourceTree = "<group>"; };
 		333000ED22D3DE5D00554162 /* Warnings.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Warnings.xcconfig; sourceTree = "<group>"; };
 		335BBD1A22A9A15E00E9071D /* GeneratedPluginRegistrant.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GeneratedPluginRegistrant.swift; sourceTree = "<group>"; };
-		33CC10ED2044A3C60003C045 /* onis_viewer.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "onis_viewer.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		33CC10ED2044A3C60003C045 /* onis_viewer.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = onis_viewer.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		33CC10F02044A3C60003C045 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		33CC10F22044A3C60003C045 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Assets.xcassets; path = Runner/Assets.xcassets; sourceTree = "<group>"; };
 		33CC10F52044A3C60003C045 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/MainMenu.xib; sourceTree = "<group>"; };
@@ -76,8 +81,13 @@
 		33E51913231747F40026EE4D /* DebugProfile.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = DebugProfile.entitlements; sourceTree = "<group>"; };
 		33E51914231749380026EE4D /* Release.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.entitlements; path = Release.entitlements; sourceTree = "<group>"; };
 		33E5194F232828860026EE4D /* AppInfo.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = AppInfo.xcconfig; sourceTree = "<group>"; };
+		7A68CB8D5C3CB38CAAC85EC5 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
+		8707ADDE72BD4B5DBD364734 /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
+		A6CEA61D75B4F1FABA4CD6F8 /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
+		A9F2F80F1A7EC9C1517F2D7F /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
+		E3D917D0BD81C059A13669E9 /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -85,6 +95,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				018959081DD7A146F6DAC97A /* Pods_RunnerTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -92,6 +103,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D1BB3608E86D19244110874E /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -125,6 +137,7 @@
 				331C80D6294CF71000263BE5 /* RunnerTests */,
 				33CC10EE2044A3C60003C045 /* Products */,
 				D73912EC22F37F3D000D13A0 /* Frameworks */,
+				FFE8AC2977CB92F0E34ABA07 /* Pods */,
 			);
 			sourceTree = "<group>";
 		};
@@ -175,8 +188,24 @@
 		D73912EC22F37F3D000D13A0 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				2446A64604057A5E541F024C /* Pods_Runner.framework */,
+				8707ADDE72BD4B5DBD364734 /* Pods_RunnerTests.framework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		FFE8AC2977CB92F0E34ABA07 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				1C81B2EFC70E239FA9EF3546 /* Pods-Runner.debug.xcconfig */,
+				7A68CB8D5C3CB38CAAC85EC5 /* Pods-Runner.release.xcconfig */,
+				0FE8233AD849D8BF5A54707A /* Pods-Runner.profile.xcconfig */,
+				A6CEA61D75B4F1FABA4CD6F8 /* Pods-RunnerTests.debug.xcconfig */,
+				E3D917D0BD81C059A13669E9 /* Pods-RunnerTests.release.xcconfig */,
+				A9F2F80F1A7EC9C1517F2D7F /* Pods-RunnerTests.profile.xcconfig */,
+			);
+			name = Pods;
+			path = Pods;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -186,6 +215,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 331C80DE294CF71000263BE5 /* Build configuration list for PBXNativeTarget "RunnerTests" */;
 			buildPhases = (
+				3BEB258D9AF41771ACC5113B /* [CP] Check Pods Manifest.lock */,
 				331C80D1294CF70F00263BE5 /* Sources */,
 				331C80D2294CF70F00263BE5 /* Frameworks */,
 				331C80D3294CF70F00263BE5 /* Resources */,
@@ -204,11 +234,13 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 33CC10FB2044A3C60003C045 /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
+				35FBDC4A8688011CD08D15C8 /* [CP] Check Pods Manifest.lock */,
 				33CC10E92044A3C60003C045 /* Sources */,
 				33CC10EA2044A3C60003C045 /* Frameworks */,
 				33CC10EB2044A3C60003C045 /* Resources */,
 				33CC110E2044A8840003C045 /* Bundle Framework */,
 				3399D490228B24CF009A79C7 /* ShellScript */,
+				030EDE60D7847E2D92C77AC5 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -291,6 +323,23 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		030EDE60D7847E2D92C77AC5 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		3399D490228B24CF009A79C7 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -328,6 +377,50 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"$FLUTTER_ROOT\"/packages/flutter_tools/bin/macos_assemble.sh && touch Flutter/ephemeral/tripwire";
+		};
+		35FBDC4A8688011CD08D15C8 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Runner-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		3BEB258D9AF41771ACC5113B /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-RunnerTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -380,6 +473,7 @@
 /* Begin XCBuildConfiguration section */
 		331C80DB294CF71000263BE5 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = A6CEA61D75B4F1FABA4CD6F8 /* Pods-RunnerTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CURRENT_PROJECT_VERSION = 1;
@@ -394,6 +488,7 @@
 		};
 		331C80DC294CF71000263BE5 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = E3D917D0BD81C059A13669E9 /* Pods-RunnerTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CURRENT_PROJECT_VERSION = 1;
@@ -408,6 +503,7 @@
 		};
 		331C80DD294CF71000263BE5 /* Profile */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = A9F2F80F1A7EC9C1517F2D7F /* Pods-RunnerTests.profile.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CURRENT_PROJECT_VERSION = 1;

--- a/apps/onis_viewer/macos/Runner.xcworkspace/contents.xcworkspacedata
+++ b/apps/onis_viewer/macos/Runner.xcworkspace/contents.xcworkspacedata
@@ -4,4 +4,7 @@
    <FileRef
       location = "group:Runner.xcodeproj">
    </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
 </Workspace>

--- a/apps/onis_viewer/pubspec.yaml
+++ b/apps/onis_viewer/pubspec.yaml
@@ -41,6 +41,7 @@ dependencies:
   # Path utilities for plugin management
   path: ^1.9.0
   flutter_advanced_table: ^1.1.5
+  flutter_secure_storage: ^9.2.2
 
 dev_dependencies:
   flutter_test:

--- a/apps/onis_viewer/windows/flutter/generated_plugin_registrant.cc
+++ b/apps/onis_viewer/windows/flutter/generated_plugin_registrant.cc
@@ -6,6 +6,9 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <flutter_secure_storage_windows/flutter_secure_storage_windows_plugin.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
+  FlutterSecureStorageWindowsPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("FlutterSecureStorageWindowsPlugin"));
 }

--- a/apps/onis_viewer/windows/flutter/generated_plugins.cmake
+++ b/apps/onis_viewer/windows/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  flutter_secure_storage_windows
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST


### PR DESCRIPTION
This PR adds username display and async disconnect functionality to the study list:

## Changes
- Add currentUsername getter and isDisconnecting state to SiteSource
- Make disconnect() method async with 10-second simulation delay
- Update StudyListView header to show 'Logged in as: username' on same line as disconnect button
- Add loading spinner and disabled state to disconnect button during disconnection
- Update DatabasePage to handle async disconnect and pass disconnecting state
- Clean up unused header methods in SiteServerLoginPanel

## User Experience
- When logged in, the study list header shows the username and a disconnect button
- Clicking disconnect shows a loading spinner for 10 seconds (simulating server response)
- After disconnection, the UI automatically switches back to the login panel
- All credentials are cleared on disconnect