### PR TITLE
feat(ui): redesign status bar with 30px height and add padding to tab labels

### DIFF
--- a/apps/onis_viewer/lib/core/constants.dart
+++ b/apps/onis_viewer/lib/core/constants.dart
@@ -15,8 +15,8 @@ class OnisViewerConstants {
   static const double minWindowHeight = 600.0;
 
   // UI dimensions
-  static const double statusBarHeight = 50.0;
-  static const double tabButtonHeight = 40.0;
+  static const double statusBarHeight = 30.0;
+  static const double tabButtonHeight = 30.0;
   static const double tabButtonWidth = 120.0;
   static const double windowControlSize = 30.0;
   static const double windowTitleBarHeight = 32.0;

--- a/apps/onis_viewer/lib/ui/status_bar/tab_bar.dart
+++ b/apps/onis_viewer/lib/ui/status_bar/tab_bar.dart
@@ -22,7 +22,7 @@ class OnisTabBar extends StatelessWidget {
     return SizedBox(
       height: OnisViewerConstants.tabButtonHeight,
       child: Row(
-        mainAxisSize: MainAxisSize.min,
+        mainAxisAlignment: MainAxisAlignment.center,
         children: availablePages.map((pageType) {
           final isSelected = currentPage == pageType;
           return Padding(

--- a/apps/onis_viewer/lib/ui/status_bar/tab_button.dart
+++ b/apps/onis_viewer/lib/ui/status_bar/tab_button.dart
@@ -20,33 +20,8 @@ class TabButton extends StatefulWidget {
   State<TabButton> createState() => _TabButtonState();
 }
 
-class _TabButtonState extends State<TabButton>
-    with SingleTickerProviderStateMixin {
-  late AnimationController _animationController;
-  late Animation<double> _scaleAnimation;
+class _TabButtonState extends State<TabButton> {
   bool _isHovered = false;
-
-  @override
-  void initState() {
-    super.initState();
-    _animationController = AnimationController(
-      duration: OnisViewerConstants.animationFast,
-      vsync: this,
-    );
-    _scaleAnimation = Tween<double>(
-      begin: 1.0,
-      end: 0.95,
-    ).animate(CurvedAnimation(
-      parent: _animationController,
-      curve: Curves.easeInOut,
-    ));
-  }
-
-  @override
-  void dispose() {
-    _animationController.dispose();
-    super.dispose();
-  }
 
   @override
   Widget build(BuildContext context) {
@@ -54,50 +29,32 @@ class _TabButtonState extends State<TabButton>
       onEnter: (_) => setState(() => _isHovered = true),
       onExit: (_) => setState(() => _isHovered = false),
       child: GestureDetector(
-        onTapDown: (_) => _animationController.forward(),
-        onTapUp: (_) => _animationController.reverse(),
-        onTapCancel: () => _animationController.reverse(),
         onTap: widget.onPressed,
-        child: AnimatedBuilder(
-          animation: _scaleAnimation,
-          builder: (context, child) {
-            return Transform.scale(
-              scale: _scaleAnimation.value,
-              child: Container(
-                width: OnisViewerConstants.tabButtonWidth,
-                height: OnisViewerConstants.tabButtonHeight,
-                decoration: BoxDecoration(
-                  color: _getBackgroundColor(),
-                  borderRadius: BorderRadius.circular(8),
-                  border: Border.all(
-                    color: _getBorderColor(),
-                    width: 1,
-                  ),
-                ),
-                child: Row(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: [
-                    Icon(
-                      widget.pageType.icon,
-                      size: 16,
-                      color: _getIconColor(),
-                    ),
-                    const SizedBox(width: OnisViewerConstants.marginSmall),
-                    Text(
-                      widget.pageType.name,
-                      style: TextStyle(
-                        fontSize: 14,
-                        fontWeight: widget.isSelected
-                            ? FontWeight.bold
-                            : FontWeight.normal,
-                        color: _getTextColor(),
-                      ),
-                    ),
-                  ],
+        child: Container(
+          height: double.infinity,
+          decoration: BoxDecoration(
+            color: _getBackgroundColor(),
+            border: Border(
+              bottom: BorderSide(
+                color: _getBorderColor(),
+                width: 2,
+              ),
+            ),
+          ),
+          child: Center(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16.0),
+              child: Text(
+                widget.pageType.name,
+                style: TextStyle(
+                  fontSize: 14,
+                  fontWeight:
+                      widget.isSelected ? FontWeight.bold : FontWeight.normal,
+                  color: _getTextColor(),
                 ),
               ),
-            );
-          },
+            ),
+          ),
         ),
       ),
     );
@@ -106,37 +63,26 @@ class _TabButtonState extends State<TabButton>
   /// Get background color based on state
   Color _getBackgroundColor() {
     if (widget.isSelected) {
-      return OnisViewerConstants.tabButtonActiveColor;
+      return Colors.transparent;
     }
     if (_isHovered) {
-      return OnisViewerConstants.tabButtonColor.withOpacity(0.8);
+      return OnisViewerConstants.tabButtonColor.withOpacity(0.3);
     }
-    return OnisViewerConstants.tabButtonColor;
+    return Colors.transparent;
   }
 
   /// Get border color based on state
   Color _getBorderColor() {
     if (widget.isSelected) {
-      return OnisViewerConstants.tabButtonActiveColor;
-    }
-    if (_isHovered) {
-      return OnisViewerConstants.primaryColor.withOpacity(0.5);
+      return OnisViewerConstants.primaryColor;
     }
     return Colors.transparent;
-  }
-
-  /// Get icon color based on state
-  Color _getIconColor() {
-    if (widget.isSelected) {
-      return OnisViewerConstants.textColor;
-    }
-    return widget.pageType.color ?? OnisViewerConstants.textSecondaryColor;
   }
 
   /// Get text color based on state
   Color _getTextColor() {
     if (widget.isSelected) {
-      return OnisViewerConstants.textColor;
+      return OnisViewerConstants.primaryColor;
     }
     return OnisViewerConstants.textSecondaryColor;
   }


### PR DESCRIPTION
## Changes

This PR redesigns the main application status bar with the following improvements:

### Status Bar Design
- **Height reduced to 30px** for a more compact appearance
- **Tab buttons take full height** without spacing between them
- **No curved borders** for a cleaner, modern look
- **No icons** on tab buttons for simplicity

### Tab Button Styling
- **Transparent background** for selected tabs (no more blue background)
- **Primary color text** (blue) for selected tabs
- **Secondary color text** (gray) for unselected tabs
- **Primary color bottom border** (2px) for selected tabs
- **Added horizontal padding** (16px) to tab labels for better spacing
- **Subtle hover effect** with light background color change

### Technical Changes
- Updated  with new height values
- Modified  to use  widgets for full width
- Redesigned  with new styling methods
- Removed spacing between adjacent buttons

### Files Modified
-  - Updated status bar dimensions
-  - Improved layout structure
-  - New styling with padding

The result is a clean, modern status bar that provides clear visual feedback for the selected tab while maintaining a professional appearance.