### PR TITLE
feat: add expandChildren parameter to expandSourceNode API

### DIFF
--- a/apps/onis_viewer/lib/plugins/database/database_plugin.dart
+++ b/apps/onis_viewer/lib/plugins/database/database_plugin.dart
@@ -35,10 +35,10 @@ class _DatabaseApiImpl implements DatabaseApi {
   Stream<DatabaseSource?> get onSelectionChanged => _selectionController.stream;
 
   @override
-  void expandSourceNode(String uid, {bool expand = true}) {
+  void expandSourceNode(String uid, {bool expand = true, bool expandChildren = false}) {
     // Direct call to static methods in DatabaseSourceBar
     if (expand) {
-      DatabaseSourceBar.expandNode(uid);
+      DatabaseSourceBar.expandNode(uid, expandChildren: expandChildren);
     } else {
       DatabaseSourceBar.collapseNode(uid);
     }

--- a/apps/onis_viewer/lib/plugins/database/database_plugin.dart
+++ b/apps/onis_viewer/lib/plugins/database/database_plugin.dart
@@ -8,6 +8,7 @@ import '../../core/page_type.dart';
 import '../../core/plugin_interface.dart';
 import 'page/database_page.dart';
 import 'public/database_api.dart';
+import 'ui/database_source_bar.dart';
 
 class _DatabaseApiImpl implements DatabaseApi {
   final _selectionController = StreamController<DatabaseSource?>.broadcast();
@@ -32,6 +33,16 @@ class _DatabaseApiImpl implements DatabaseApi {
 
   @override
   Stream<DatabaseSource?> get onSelectionChanged => _selectionController.stream;
+
+  @override
+  void expandSourceNode(String uid, {bool expand = true}) {
+    // Direct call to static methods in DatabaseSourceBar
+    if (expand) {
+      DatabaseSourceBar.expandNode(uid);
+    } else {
+      DatabaseSourceBar.collapseNode(uid);
+    }
+  }
 }
 
 /// Database page type constant

--- a/apps/onis_viewer/lib/plugins/database/public/database_api.dart
+++ b/apps/onis_viewer/lib/plugins/database/public/database_api.dart
@@ -16,5 +16,5 @@ abstract class DatabaseApi {
   /// Expand or collapse a source node in the source tree
   /// [uid] - The UID of the source to expand/collapse
   /// [expand] - true to expand, false to collapse
-  void expandSourceNode(String uid, {bool expand = true});
+  void expandSourceNode(String uid, {bool expand = true, bool expandChildren = false});
 }

--- a/apps/onis_viewer/lib/plugins/database/public/database_api.dart
+++ b/apps/onis_viewer/lib/plugins/database/public/database_api.dart
@@ -12,4 +12,9 @@ abstract class DatabaseApi {
 
   /// Stream emitting selection changes
   Stream<DatabaseSource?> get onSelectionChanged;
+
+  /// Expand or collapse a source node in the source tree
+  /// [uid] - The UID of the source to expand/collapse
+  /// [expand] - true to expand, false to collapse
+  void expandSourceNode(String uid, {bool expand = true});
 }

--- a/apps/onis_viewer/lib/plugins/database/ui/database_source_bar.dart
+++ b/apps/onis_viewer/lib/plugins/database/ui/database_source_bar.dart
@@ -20,6 +20,16 @@ class DatabaseSourceBar extends StatefulWidget {
 
   @override
   State<DatabaseSourceBar> createState() => _DatabaseSourceBarState();
+
+  /// Static method to expand a node by UID
+  static void expandNode(String uid) {
+    _DatabaseSourceBarState.expandNode(uid);
+  }
+
+  /// Static method to collapse a node by UID
+  static void collapseNode(String uid) {
+    _DatabaseSourceBarState.collapseNode(uid);
+  }
 }
 
 class _DatabaseSourceBarState extends State<DatabaseSourceBar> {
@@ -28,12 +38,18 @@ class _DatabaseSourceBarState extends State<DatabaseSourceBar> {
   final Set<String> _expanded = <String>{};
   DatabaseSource? _selected;
 
+  // Static reference to the current instance for direct access
+  static _DatabaseSourceBarState? _currentInstance;
+
   @override
   void initState() {
     super.initState();
     _manager = _api.sources;
     _selected = widget.selectedSource;
     _manager.addListener(_onManagerChanged);
+
+    // Register this instance as the current one
+    _currentInstance = this;
   }
 
   @override
@@ -52,7 +68,25 @@ class _DatabaseSourceBarState extends State<DatabaseSourceBar> {
   @override
   void dispose() {
     _manager.removeListener(_onManagerChanged);
+    // Clear the static reference if this is the current instance
+    if (_currentInstance == this) {
+      _currentInstance = null;
+    }
     super.dispose();
+  }
+
+  /// Static method to expand a node by UID
+  static void expandNode(String uid) {
+    _currentInstance?.setState(() {
+      _currentInstance!._expanded.add(uid);
+    });
+  }
+
+  /// Static method to collapse a node by UID
+  static void collapseNode(String uid) {
+    _currentInstance?.setState(() {
+      _currentInstance!._expanded.remove(uid);
+    });
   }
 
   @override

--- a/apps/onis_viewer/lib/plugins/database/ui/database_source_bar.dart
+++ b/apps/onis_viewer/lib/plugins/database/ui/database_source_bar.dart
@@ -22,8 +22,8 @@ class DatabaseSourceBar extends StatefulWidget {
   State<DatabaseSourceBar> createState() => _DatabaseSourceBarState();
 
   /// Static method to expand a node by UID
-  static void expandNode(String uid) {
-    _DatabaseSourceBarState.expandNode(uid);
+  static void expandNode(String uid, {bool expandChildren = false}) {
+    _DatabaseSourceBarState.expandNode(uid, expandChildren: expandChildren);
   }
 
   /// Static method to collapse a node by UID
@@ -76,9 +76,21 @@ class _DatabaseSourceBarState extends State<DatabaseSourceBar> {
   }
 
   /// Static method to expand a node by UID
-  static void expandNode(String uid) {
+  static void expandNode(String uid, {bool expandChildren = false}) {
     _currentInstance?.setState(() {
       _currentInstance!._expanded.add(uid);
+
+      if (expandChildren) {
+        // Expand immediate children
+        final source = _currentInstance!._manager.allSources
+            .where((s) => s.uid == uid)
+            .firstOrNull;
+        if (source != null) {
+          for (final child in source.subSources) {
+            _currentInstance!._expanded.add(child.uid);
+          }
+        }
+      }
     });
   }
 

--- a/apps/onis_viewer/lib/plugins/sources/site-server/site_source.dart
+++ b/apps/onis_viewer/lib/plugins/sources/site-server/site_source.dart
@@ -160,6 +160,10 @@ class SiteSource extends DatabaseSource {
     _isLoggingIn = true;
     notifyListeners();
 
+    // Simulate slow server response for login
+    await Future.delayed(const Duration(seconds: 10));
+
+    // Store or clear credentials based on remember flag
     if (remember) {
       await SiteServerCredentialStore.save(
         uid,
@@ -171,14 +175,18 @@ class SiteSource extends DatabaseSource {
       await SiteServerCredentialStore.clear(uid);
     }
 
-    // Simulate slow server response
-    await Future.delayed(const Duration(seconds: 1));
-
-    // Mark source as connected
-    isActive = true; // Triggers listeners via setter
+    // Mark source as active
+    isActive = true;
 
     // Create child sources after successful authentication
     _createChildSources();
+
+    // Auto-expand the site source node in the source tree
+    final api = OVApi();
+    final dbApi = api.plugins.getPublicApi('onis_database_plugin');
+    if (dbApi != null) {
+      dbApi.expandSourceNode(uid, expand: true);
+    }
 
     // Reset logging-in flag
     _isLoggingIn = false;

--- a/apps/onis_viewer/lib/plugins/sources/site-server/site_source.dart
+++ b/apps/onis_viewer/lib/plugins/sources/site-server/site_source.dart
@@ -161,7 +161,7 @@ class SiteSource extends DatabaseSource {
     notifyListeners();
 
     // Simulate slow server response for login
-    await Future.delayed(const Duration(seconds: 10));
+    await Future.delayed(const Duration(seconds: 1));
 
     // Store or clear credentials based on remember flag
     if (remember) {
@@ -185,7 +185,7 @@ class SiteSource extends DatabaseSource {
     final api = OVApi();
     final dbApi = api.plugins.getPublicApi('onis_database_plugin');
     if (dbApi != null) {
-      dbApi.expandSourceNode(uid, expand: true);
+      dbApi.expandSourceNode(uid, expand: true, expandChildren: true);
     }
 
     // Reset logging-in flag


### PR DESCRIPTION
Add expandChildren parameter to control recursive expansion of child nodes in the source tree. When true, expands parent and all immediate children. SiteSource now uses this to show all child partitions after authentication.