### PR TITLE
Fix parent-based selection after disconnect and refactor to avoid code duplication

### DIFF
--- a/apps/onis_viewer/lib/plugins/database/database_plugin.dart
+++ b/apps/onis_viewer/lib/plugins/database/database_plugin.dart
@@ -48,7 +48,18 @@ class _DatabaseApiImpl implements DatabaseApi {
 
     // If we know which source was destroyed, try to find its parent first
     if (destroyedSourceUid != null) {
-      // Look for a source that has the destroyed source as a child
+      // First, try to find a source with this exact UID (in case it's a parent site UID)
+      final exactMatch = allSources
+          .where((source) => source.uid == destroyedSourceUid)
+          .firstOrNull;
+      if (exactMatch != null) {
+        _selected = exactMatch;
+        debugPrint(
+            'Selected exact match for destroyed source: ${exactMatch.name}');
+        return;
+      }
+
+      // If no exact match, look for a source that has the destroyed source as a child
       final parentSource = allSources.where((source) {
         return source.subSources
             .any((child) => child.uid == destroyedSourceUid);

--- a/apps/onis_viewer/lib/plugins/sources/site-server/site_source.dart
+++ b/apps/onis_viewer/lib/plugins/sources/site-server/site_source.dart
@@ -146,12 +146,6 @@ class SiteChildSource extends DatabaseSource {
     // Reset local disconnecting state
     _isDisconnecting = false;
     notifyListeners();
-
-    // Check and fix selection after disconnect completes
-    final dbApi = api.plugins.getPublicApi('onis_database_plugin');
-    if (dbApi != null) {
-      dbApi.checkAndFixSelection(uid);
-    }
   }
 }
 
@@ -235,6 +229,13 @@ class SiteSource extends DatabaseSource {
         'Disconnected from site: $name (removed ${childSources.length} child sources)');
 
     notifyListeners();
+
+    // Check and fix selection after disconnect completes
+    // Use the current site UID for selection logic
+    final dbApi = api.plugins.getPublicApi('onis_database_plugin');
+    if (dbApi != null) {
+      dbApi.checkAndFixSelection(uid);
+    }
   }
 
   /// Mock login: optionally store credentials, wait 10 seconds, then mark active


### PR DESCRIPTION
This PR fixes the parent-based selection logic that was broken after the merge and refactors the code to avoid duplication. When disconnecting from a child source (partition, album, etc.), the parent site source is now properly selected instead of the first available source.