### PR TITLE
Refactor AsyncRequest interface to include request type and data as members

### DIFF
--- a/apps/onis_viewer/lib/api/request/async_request.dart
+++ b/apps/onis_viewer/lib/api/request/async_request.dart
@@ -60,12 +60,16 @@ abstract class AsyncResponse {
 
 /// Interface for asynchronous requests that can be sent and cancelled
 abstract class AsyncRequest {
-  /// Send the request with the provided JSON data
+  /// The type of request
+  RequestType get requestType;
+
+  /// The JSON data for the request
+  Map<String, dynamic>? get data;
+
+  /// Send the request
   ///
-  /// [type] - The type of request to send
-  /// [data] - The JSON structure containing the request data
   /// Returns a Future that completes with the response when the request is finished
-  Future<AsyncResponse> send(RequestType type, [Map<String, dynamic>? data]);
+  Future<AsyncResponse> send();
 
   /// Cancel the current request if it's in progress
   ///

--- a/apps/onis_viewer/lib/plugins/sources/site-server/request/site_async_request.dart
+++ b/apps/onis_viewer/lib/plugins/sources/site-server/request/site_async_request.dart
@@ -10,6 +10,14 @@ class SiteAsyncRequest implements AsyncRequest {
   /// The base URL for the HTTP requests
   final String baseUrl;
 
+  /// The type of request
+  @override
+  final RequestType requestType;
+
+  /// The JSON data for the request
+  @override
+  final Map<String, dynamic>? data;
+
   /// HTTP client for making requests
   final http.Client _client;
 
@@ -22,10 +30,16 @@ class SiteAsyncRequest implements AsyncRequest {
   /// Constructor
   ///
   /// [baseUrl] - The base URL for the HTTP requests
-  SiteAsyncRequest({required this.baseUrl}) : _client = http.Client();
+  /// [requestType] - The type of request to make
+  /// [data] - The JSON data for the request
+  SiteAsyncRequest({
+    required this.baseUrl,
+    required this.requestType,
+    this.data,
+  }) : _client = http.Client();
 
   @override
-  Future<void> send(RequestType type, [Map<String, dynamic>? data]) async {
+  Future<AsyncResponse> send() async {
     // Cancel any existing request
     await cancel();
 
@@ -34,7 +48,7 @@ class SiteAsyncRequest implements AsyncRequest {
 
     try {
       // Build the request URL based on the request type
-      final url = _buildUrl(type);
+      final url = _buildUrl(requestType);
 
       // Create the HTTP request
       _currentRequest = http.Request('POST', Uri.parse(url));
@@ -50,26 +64,26 @@ class SiteAsyncRequest implements AsyncRequest {
 
       // Check if request was cancelled
       if (_cancellationController!.isClosed) {
-        return;
+        return _createCancelledResponse();
       }
 
       // Handle the response
       if (response.statusCode >= 200 && response.statusCode < 300) {
-        // Success - you might want to handle the response data here
+        // Success - parse the response data
         final responseBody = await response.stream.bytesToString();
-        print('Request successful: ${response.statusCode} - $responseBody');
+        final responseData = jsonDecode(responseBody) as Map<String, dynamic>?;
+
+        return _createSuccessResponse(response.statusCode, responseData);
       } else {
         // Error
-        throw HttpRequestException(
-          'HTTP request failed with status: ${response.statusCode}',
-          response.statusCode,
-        );
+        final responseBody = await response.stream.bytesToString();
+        return _createErrorResponse(response.statusCode, responseBody);
       }
     } catch (e) {
       if (e is HttpRequestException) {
-        rethrow;
+        return _createErrorResponse(e.statusCode, e.message);
       }
-      throw HttpRequestException('HTTP request failed: $e', 0);
+      return _createErrorResponse(0, 'HTTP request failed: $e');
     } finally {
       _currentRequest = null;
       await _cancellationController?.close();
@@ -124,6 +138,66 @@ class SiteAsyncRequest implements AsyncRequest {
     cancel();
     _client.close();
   }
+
+  /// Create a success response
+  AsyncResponse _createSuccessResponse(
+      int statusCode, Map<String, dynamic>? data) {
+    return _SiteAsyncResponse(
+      isSuccess: true,
+      statusCode: statusCode,
+      data: data,
+      errorMessage: null,
+      metadata: null,
+    );
+  }
+
+  /// Create an error response
+  AsyncResponse _createErrorResponse(int statusCode, String errorMessage) {
+    return _SiteAsyncResponse(
+      isSuccess: false,
+      statusCode: statusCode,
+      data: null,
+      errorMessage: errorMessage,
+      metadata: null,
+    );
+  }
+
+  /// Create a cancelled response
+  AsyncResponse _createCancelledResponse() {
+    return _SiteAsyncResponse(
+      isSuccess: false,
+      statusCode: null,
+      data: null,
+      errorMessage: 'Request was cancelled',
+      metadata: null,
+    );
+  }
+}
+
+/// Implementation of AsyncResponse for SiteAsyncRequest
+class _SiteAsyncResponse implements AsyncResponse {
+  @override
+  final bool isSuccess;
+
+  @override
+  final int? statusCode;
+
+  @override
+  final Map<String, dynamic>? data;
+
+  @override
+  final String? errorMessage;
+
+  @override
+  final Map<String, dynamic>? metadata;
+
+  _SiteAsyncResponse({
+    required this.isSuccess,
+    required this.statusCode,
+    required this.data,
+    required this.errorMessage,
+    required this.metadata,
+  });
 }
 
 /// Exception thrown when HTTP requests fail

--- a/apps/onis_viewer/lib/plugins/sources/site-server/site_source.dart
+++ b/apps/onis_viewer/lib/plugins/sources/site-server/site_source.dart
@@ -3,8 +3,10 @@ import 'dart:core';
 import 'package:flutter/material.dart';
 import 'package:onis_viewer/api/ov_api.dart';
 
+import '../../../api/request/async_request.dart';
 import '../../../core/database_source.dart';
 import 'credentials/credential_store.dart';
+import 'request/site_async_request.dart';
 import 'ui/site_server_connection_panel.dart';
 import 'ui/site_server_login_panel.dart';
 
@@ -161,6 +163,10 @@ class SiteSource extends DatabaseSource {
   bool _lastRemember = false;
   bool _isLoggingIn = false;
   bool _isDisconnecting = false;
+
+  /// Map to store SiteAsyncRequest instances
+  /// First key: source UID, Second key: RequestType
+  final Map<String, Map<RequestType, List<SiteAsyncRequest>>> _requests = {};
 
   /// Get the current logged-in username (if any)
   @override


### PR DESCRIPTION
This PR refactors the AsyncRequest interface to include request type and data as members, making requests immutable and improving encapsulation. The send() method no longer takes parameters and uses stored members instead. Added proper AsyncResponse handling and updated SiteSource to store requests efficiently.