### PR TITLE
feat(database): implement toolbar icon enabling with dynamic refresh

### DIFF
--- a/apps/onis_viewer/lib/core/database_source.dart
+++ b/apps/onis_viewer/lib/core/database_source.dart
@@ -205,27 +205,7 @@ class DatabaseSource extends ChangeNotifier {
   Widget? buildConnectionPanel(BuildContext context) => null;
 
   // Capability methods for toolbar actions
-  // These methods should be overridden by subclasses to provide specific capabilities
-
-  /// Check if the source supports opening databases
-  /// Default implementation returns false
-  bool get canOpen => false;
-
-  /// Check if the source supports importing data
-  /// Default implementation returns false
-  bool get canImport => isActive;
-
-  /// Check if the source supports exporting data
-  /// Default implementation returns false
-  bool get canExport => false;
-
-  /// Check if the source supports transferring data
-  /// Default implementation returns false
-  bool get canTransfer => false;
-
-  /// Check if the source supports searching
-  /// Default implementation returns true when the source is active/connected
-  bool get canSearch => isActive;
+  // These methods have been moved to DatabaseController for centralized state management
 
   /// Search method - should be overridden by subclasses
   /// Default implementation does nothing

--- a/apps/onis_viewer/lib/core/database_source.dart
+++ b/apps/onis_viewer/lib/core/database_source.dart
@@ -213,7 +213,7 @@ class DatabaseSource extends ChangeNotifier {
 
   /// Check if the source supports importing data
   /// Default implementation returns false
-  bool get canImport => false;
+  bool get canImport => isActive;
 
   /// Check if the source supports exporting data
   /// Default implementation returns false

--- a/apps/onis_viewer/lib/plugins/database/page/database_controller.dart
+++ b/apps/onis_viewer/lib/plugins/database/page/database_controller.dart
@@ -89,6 +89,13 @@ class DatabaseController extends ChangeNotifier {
     return _studiesBySource[sourceUid] ?? [];
   }
 
+  /// Check if there are any studies selected for the given source
+  /// Returns true if at least one study is selected, false otherwise
+  bool hasSelectedStudies(String sourceUid) {
+    final selectedStudies = _selectedStudiesBySource[sourceUid];
+    return selectedStudies != null && selectedStudies.isNotEmpty;
+  }
+
   List<Study> getSelectedStudiesForSource(String sourceUid) {
     return _selectedStudiesBySource[sourceUid] ?? [];
   }
@@ -414,9 +421,7 @@ class DatabaseController extends ChangeNotifier {
   /// Check if import is available for the given source
   /// Returns true if the source is connected
   bool canImport(String sourceUid) {
-    final api = OVApi();
-    final source = api.sources.findSourceByUid(sourceUid);
-    return source?.isActive ?? false;
+    return canSearch(sourceUid);
   }
 
   /// Check if export is available for the given source
@@ -424,37 +429,19 @@ class DatabaseController extends ChangeNotifier {
   bool canExport(String sourceUid) {
     final api = OVApi();
     final source = api.sources.findSourceByUid(sourceUid);
-    if (source?.isActive != true) {
-      return false;
-    }
-
-    final selectedStudies = getSelectedStudiesForSource(sourceUid);
-    return selectedStudies.isNotEmpty;
+    if (source == null) return false;
+    return source.isActive && hasSelectedStudies(sourceUid);
   }
 
   /// Check if open is available for the given source
   /// Returns true if the source is connected and at least one study is selected
   bool canOpen(String sourceUid) {
-    final api = OVApi();
-    final source = api.sources.findSourceByUid(sourceUid);
-    if (source?.isActive != true) {
-      return false;
-    }
-
-    final selectedStudies = getSelectedStudiesForSource(sourceUid);
-    return selectedStudies.isNotEmpty;
+    return canExport(sourceUid);
   }
 
   /// Check if transfer is available for the given source
   /// Returns true if the source is connected and at least one study is selected
   bool canTransfer(String sourceUid) {
-    final api = OVApi();
-    final source = api.sources.findSourceByUid(sourceUid);
-    if (source?.isActive != true) {
-      return false;
-    }
-
-    final selectedStudies = getSelectedStudiesForSource(sourceUid);
-    return selectedStudies.isNotEmpty;
+    return canExport(sourceUid);
   }
 }

--- a/apps/onis_viewer/lib/plugins/database/page/database_controller.dart
+++ b/apps/onis_viewer/lib/plugins/database/page/database_controller.dart
@@ -402,4 +402,59 @@ class DatabaseController extends ChangeNotifier {
   void showSettings() {
     debugPrint('Show database settings');
   }
+
+  /// Check if search is available for the given source
+  /// Returns true if the source is connected
+  bool canSearch(String sourceUid) {
+    final api = OVApi();
+    final source = api.sources.findSourceByUid(sourceUid);
+    return source?.isActive ?? false;
+  }
+
+  /// Check if import is available for the given source
+  /// Returns true if the source is connected
+  bool canImport(String sourceUid) {
+    final api = OVApi();
+    final source = api.sources.findSourceByUid(sourceUid);
+    return source?.isActive ?? false;
+  }
+
+  /// Check if export is available for the given source
+  /// Returns true if the source is connected and at least one study is selected
+  bool canExport(String sourceUid) {
+    final api = OVApi();
+    final source = api.sources.findSourceByUid(sourceUid);
+    if (source?.isActive != true) {
+      return false;
+    }
+
+    final selectedStudies = getSelectedStudiesForSource(sourceUid);
+    return selectedStudies.isNotEmpty;
+  }
+
+  /// Check if open is available for the given source
+  /// Returns true if the source is connected and at least one study is selected
+  bool canOpen(String sourceUid) {
+    final api = OVApi();
+    final source = api.sources.findSourceByUid(sourceUid);
+    if (source?.isActive != true) {
+      return false;
+    }
+
+    final selectedStudies = getSelectedStudiesForSource(sourceUid);
+    return selectedStudies.isNotEmpty;
+  }
+
+  /// Check if transfer is available for the given source
+  /// Returns true if the source is connected and at least one study is selected
+  bool canTransfer(String sourceUid) {
+    final api = OVApi();
+    final source = api.sources.findSourceByUid(sourceUid);
+    if (source?.isActive != true) {
+      return false;
+    }
+
+    final selectedStudies = getSelectedStudiesForSource(sourceUid);
+    return selectedStudies.isNotEmpty;
+  }
 }

--- a/apps/onis_viewer/lib/plugins/database/page/database_page.dart
+++ b/apps/onis_viewer/lib/plugins/database/page/database_page.dart
@@ -92,11 +92,12 @@ class _DatabasePageState extends BasePageState<DatabasePage> {
           _controller.onSearch(selected.uid);
         }
       },
-      canOpen: selected?.canOpen ?? false,
-      canImport: selected?.canImport ?? false,
-      canExport: selected?.canExport ?? false,
-      canTransfer: selected?.canTransfer ?? false,
-      canSearch: selected?.canSearch ?? false,
+      canOpen: selected != null ? _controller.canOpen(selected.uid) : false,
+      canImport: selected != null ? _controller.canImport(selected.uid) : false,
+      canExport: selected != null ? _controller.canExport(selected.uid) : false,
+      canTransfer:
+          selected != null ? _controller.canTransfer(selected.uid) : false,
+      canSearch: selected != null ? _controller.canSearch(selected.uid) : false,
     );
   }
 

--- a/apps/onis_viewer/lib/plugins/database/page/database_page.dart
+++ b/apps/onis_viewer/lib/plugins/database/page/database_page.dart
@@ -75,29 +75,38 @@ class _DatabasePageState extends BasePageState<DatabasePage> {
 
   @override
   Widget? buildPageHeader() {
-    // Get the selected source to determine capabilities
-    final selected = _dbApi?.selectedSource;
-
     // Return the database toolbar as the custom page header
-    return DatabaseToolbar(
-      onPreferences: () => _controller.openPreferences(),
-      onImport: () => _controller.importData(),
-      onExport: () => _controller.exportData(),
-      onTransfer: () => _controller.transferData(),
-      onOpen: () => _controller.openDatabaseFromToolbar(),
-      selectedLocation: 'Local computer',
-      onSearch: () {
+    // Use AnimatedBuilder to rebuild when controller changes
+    return AnimatedBuilder(
+      animation: _controller,
+      builder: (context, child) {
+        // Get the selected source to determine capabilities
         final selected = _dbApi?.selectedSource;
-        if (selected != null) {
-          _controller.onSearch(selected.uid);
-        }
+
+        return DatabaseToolbar(
+          onPreferences: () => _controller.openPreferences(),
+          onImport: () => _controller.importData(),
+          onExport: () => _controller.exportData(),
+          onTransfer: () => _controller.transferData(),
+          onOpen: () => _controller.openDatabaseFromToolbar(),
+          selectedLocation: 'Local computer',
+          onSearch: () {
+            final selected = _dbApi?.selectedSource;
+            if (selected != null) {
+              _controller.onSearch(selected.uid);
+            }
+          },
+          canOpen: selected != null ? _controller.canOpen(selected.uid) : false,
+          canImport:
+              selected != null ? _controller.canImport(selected.uid) : false,
+          canExport:
+              selected != null ? _controller.canExport(selected.uid) : false,
+          canTransfer:
+              selected != null ? _controller.canTransfer(selected.uid) : false,
+          canSearch:
+              selected != null ? _controller.canSearch(selected.uid) : false,
+        );
       },
-      canOpen: selected != null ? _controller.canOpen(selected.uid) : false,
-      canImport: selected != null ? _controller.canImport(selected.uid) : false,
-      canExport: selected != null ? _controller.canExport(selected.uid) : false,
-      canTransfer:
-          selected != null ? _controller.canTransfer(selected.uid) : false,
-      canSearch: selected != null ? _controller.canSearch(selected.uid) : false,
     );
   }
 

--- a/apps/onis_viewer/lib/plugins/sources/site-server/site_source.dart
+++ b/apps/onis_viewer/lib/plugins/sources/site-server/site_source.dart
@@ -74,7 +74,6 @@ class SiteChildSource extends DatabaseSource {
     }
   }
 
-  @override
   bool get canSearch => isActive;
 
   /// Get the current username from the parent site source
@@ -329,7 +328,6 @@ class SiteSource extends DatabaseSource {
     );
   }
 
-  @override
   bool get canSearch => isActive;
 
   //@override

--- a/apps/onis_viewer/lib/plugins/sources/site-server/site_source.dart
+++ b/apps/onis_viewer/lib/plugins/sources/site-server/site_source.dart
@@ -74,8 +74,6 @@ class SiteChildSource extends DatabaseSource {
     }
   }
 
-  bool get canSearch => isActive;
-
   /// Get the current username from the parent site source
   @override
   String? get currentUsername {
@@ -327,8 +325,6 @@ class SiteSource extends DatabaseSource {
       onSave: () {},
     );
   }
-
-  bool get canSearch => isActive;
 
   //@override
   //void search() {


### PR DESCRIPTION
This PR implements dynamic toolbar icon enabling/disabling based on source connection status and study selection, with proper state synchronization.

## New Features
- Add capability checking methods to DatabaseController (canSearch, canImport, canExport, canOpen, canTransfer)
- Centralize all toolbar capability logic in DatabaseController for consistent state management
- Implement dynamic toolbar refresh when study selection changes

## Architecture Improvements
- Remove capability methods from DatabaseSource classes for cleaner separation of concerns
- Move all capability checking from source classes to DatabaseController
- Ensure proper state synchronization between study list and toolbar

## Bug Fixes
- Fix database toolbar not refreshing when studies are selected/unselected
- Wrap DatabaseToolbar in AnimatedBuilder to listen to DatabaseController changes
- Ensure Export, Open, Transfer buttons enable/disable based on study selection

## Technical Details
- canSearch/canImport: enabled when source is connected
- canExport/canOpen/canTransfer: enabled when source is connected AND studies are selected
- Toolbar updates in real-time when study selection changes
- Proper cleanup of unused methods and @override annotations

## Files Modified
- DatabaseController: Added capability methods
- DatabaseSource: Removed capability methods
- DatabasePage: Added AnimatedBuilder for toolbar refresh
- SiteSource classes: Removed canSearch methods

All quality checks pass and the toolbar now provides responsive feedback based on current application state.