### PR TITLE
feat(site-server): integrate config service with drogon HTTP server

### DIFF
--- a/apps/onis_site_server/include/network/drogon/drogon_http_server.hpp
+++ b/apps/onis_site_server/include/network/drogon/drogon_http_server.hpp
@@ -2,6 +2,7 @@
 
 #include <drogon/drogon.h>
 #include <memory>
+#include "../../../include/services/config/config_service.hpp"
 #include "../../../include/services/requests/request_service.hpp"
 #include "./drogon_http_controller.hpp"
 #include "onis_kit/include/core/thread.hpp"
@@ -18,9 +19,11 @@ typedef std::weak_ptr<drogon_http_server> drogon_http_server_wptr;
 
 class drogon_http_server : public dgc::thread {
 public:
-  static drogon_http_server_ptr create(const request_service_ptr& srv);
+  static drogon_http_server_ptr create(const request_service_ptr& srv,
+                                       const config_service_ptr& config);
 
-  drogon_http_server(const request_service_ptr& srv);
+  drogon_http_server(const request_service_ptr& srv,
+                     const config_service_ptr& config);
   ~drogon_http_server();
 
   // init / exit:
@@ -29,6 +32,7 @@ public:
 
   // properties:
   request_service_ptr get_request_service() const;
+  config_service_ptr get_config_service() const;
 
 protected:
   static void worker_thread(drogon_http_server* server,
@@ -36,5 +40,6 @@ protected:
 
   std::thread th_;
   request_service_ptr rqsrv_;
+  config_service_ptr config_service_;
   http_drogon_controller_ptr controller_;
 };

--- a/apps/onis_site_server/src/site_api.cpp
+++ b/apps/onis_site_server/src/site_api.cpp
@@ -89,7 +89,8 @@ bool site_api::initialize(const std::string& config_file_path) {
     }
 
     // Initialize HTTP server
-    http_server_ = drogon_http_server::create(request_service_);
+    http_server_ =
+        drogon_http_server::create(request_service_, config_service_);
     if (!http_server_) {
       std::cerr << "site_api: Failed to create HTTP server" << std::endl;
       return false;


### PR DESCRIPTION
Integrate configuration service with drogon HTTP server to use config parameters instead of hardcoded values.